### PR TITLE
Update instructions and deps for getting started

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+ruby 2.7.6
+python 3.10.7
+nodejs 16.13.1

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gem "webrick" # https://github.com/jekyll/jekyll/issues/8523 Ruby 3.0 removed but jekyll requires
 
 gem "github-pages", group: :jekyll_plugins
+
+gem "rake", "~> 13.0"
+
+gem "html-proofer", "~> 3.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,14 @@ GEM
     html-pipeline (2.14.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.19.2)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -231,12 +239,17 @@ GEM
     multipart-post (2.2.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
+    rainbow (3.1.1)
+    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -269,13 +282,17 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
+    yell (2.2.2)
 
 PLATFORMS
   x86_64-darwin-16
+  x86_64-linux
 
 DEPENDENCIES
   github-pages
+  html-proofer (~> 3.19)
+  rake (~> 13.0)
   webrick
 
 BUNDLED WITH
-   2.3.17
+   2.3.24

--- a/README.md
+++ b/README.md
@@ -59,11 +59,20 @@ Verify that you are on the `main` branch
 $ git branch
 ```
 
-Follow the instructions below to run the website on a local server. GitHub recommends using [Bundler](http://bundler.io/) to install and run Jekyll. [Ruby](https://www.ruby-lang.org) is a pre-requisite. One of the project dependencies (nokogiri) requires a Ruby version >= 2.1.0. See the [Jekyll Quick-start Guide](https://jekyllrb.com/docs/quickstart/) for more info.
+Follow the instructions below to run the website on a local server.
+
+#### Prerequisites
+
+- [Ruby](https://www.ruby-lang.org) (>= 2.5.0 & < 3.X)
+  - See the [Jekyll Quick-start Guide](https://jekyllrb.com/docs/quickstart/) for more info.
+- NodeJS (>= 10.0)
+- Python (for node-gyp)
 
 #### Install Jekyll
 
-You might need to use ```$ sudo gem install jekyll bundler foreman```
+GitHub recommends using [Bundler](http://bundler.io/) to install and run Jekyll.
+
+You might need to use `$ sudo gem install jekyll bundler foreman`
 
 ```bash
 $ gem install jekyll bundler
@@ -71,8 +80,6 @@ $ bundle install
 ```
 
 #### Install Node Dependencies
-
-You will need Node v10.0 or greater to compile frontend assets. We're using [Webpack](https://webpack.js.org/) to compile Scss and JavaScript.
 
 You'll need to install all the JS dependencies.
 
@@ -82,6 +89,8 @@ $ npm install .
 ```
 
 #### Compile CSS & JS
+
+We're using [Webpack](https://webpack.js.org/) to compile Scss and JavaScript.
 
 ```bash
 $ npm run build


### PR DESCRIPTION
This PR makes a few changes to support issues I ran into getting setup:

- Ignores `node_modules`
- Explicitly sets versions for supporting tech in `.tool-version` (supported by asdf-vm)
- Adds Rake & HTML Proofer as dependencies
- Updates the README to explicitly call out prereqs and their versions and moves supporting info into relevant sections

I am not a Ruby nor Jekyll user so perhaps this patch isn't 100% accurate and maybe we left those deps out on purpose 😅