### PR TITLE
Update the covid19 page with 2023's policy.

### DIFF
--- a/_pages/covid19.html
+++ b/_pages/covid19.html
@@ -14,7 +14,7 @@ title: COVID-19 In-Person Policy
   <section class="section-pad">
     <div class="row column">
         <h2 class="demp">
-        DjangoCon US is committed to providing a safe in-person conference through the use of vaccine verification and a mask mandate.
+        DjangoCon US is committed to providing a safe in-person conference through the use of testing and a mask mandate.
         </h2>
     </div>
   </section>
@@ -23,42 +23,33 @@ title: COVID-19 In-Person Policy
     <div class="row">
         <div class="column small-12 medium-6">
             <p>
-              In order to keep conference attendees safe, DjangoCon US will have an indoor mask mandate, a required proof of negative COVID test, and a vaccine verification process in-person in Durham as well as an online verification before the conference. If you are not familiar, we suggest you check out the <a href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-during-covid19.html">CDC's Domestic Travel guidelines to stay safe</a>.
+              In order to keep conference attendees safe, DjangoCon US will have an indoor mask mandate and required proof of negative COVID test. We strongly recommend that people get fully vaccinated and boosted before the conference as well. If you are not familiar, we suggest you check out the <a href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-during-covid19.html">CDC's Domestic Travel guidelines to stay safe</a>.
               <br />
               <br />
-              <strong>Update:</strong> On September 1, 2022, the CDC officially <a href="https://www.cdc.gov/media/releases/2022/s0901-covid-19-booster.html">recommended the new bivalent boosters</a> from Moderna and Pfizer/BioNTech. Based on these recommendations, we are now requiring one of the two conditions to be met:
-              <ul>
-                <li>
-                  If it has been fewer than 5 months since you have completed your initial vaccination schedule
-                  (2 doses for either Pfizer or Moderna or 1 dose for Johnson and Johnson or Novavax in the USA),
-                  you are not required to get an additional booster.
-                </li>
-                <li>
-                  If you have received any booster since you have completed your initial vaccination schedule,
-                   you are not required to get an additional booster at this time.
-                  </li>
-                <li>
-                  Otherwise, you are required to get a COVID booster if it is available in your country of residence.
-                </li>
-              </ol>
+              We are requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a rapid test, you must take it within 24 hours of your first ticketed day. We will have tests on site if you wish to test when you arrive. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending Monday's sessions, the test must be taken no earlier than Thursday, October 13).
               <br />
               <br />
-              We are also requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending a tutorial, the test must be taken no earlier than Thursday, October 13). If you are taking a rapid test that offers results in under 24 hours, you must take it within 72 hours of your first ticketed day.
-              <br />
-              <br />
-              For vaccine verification, we will be using <a href="https://sharemy.health/">Share My Health</a>, a third-party vendor recognized as a leader in the space, which PyCon US 2022 also used. In order to pass the vaccine verification, you must have be up to date on your vaccine (including eligible boosters). We will be sending the instructions to in-person ticket-holders to verify your vaccine status prior to the conference.
+              We will be sending the testing instructions to in-person ticket-holders prior to the conference.
               <br />
               <br />
               The conference will provide KN95 and/or N95 masks for people to wear. We will be asking that all attendees wear a certified KN95 / N95 respirator mask (with no outflow vent) while inside. As N95 is an American standard, masks certified by other governments to similar standards (e.g. PM2.5 and KF94) will also be allowed.
               <br />
               <br />
-              Similar to PyCon US 2022, we will have a three strike policy for masks not being worn inside the venue. If you are seen without a mask on, you will be issued a strike by the organizing committee. Upon receiving your third strike, you will not be allowed to enter the venue and will not be issued a refund. Please make our job easy and keep your mask on while inside at all times.
+              Similar to DjangoCon US 2022, we will have a three strike policy for masks not being worn inside the venue. If you are seen without a mask on, you will be issued a strike by the organizing committee. Upon receiving your third strike, you will not be allowed to enter the venue and will not be issued a refund. Please make our job easy and keep your mask on while inside at all times.
               <br />
               <br />
-              Speakers will be allowed to remove their masks while speaking at the lectern. This includes tutorial presenters, but presenters will need to put their masks back on while helping students as that typically requires being close enough to read their screens.
+              The following cases are the only exceptions to not wear a mask while at the venue:
+              <br />
+              🌞 You're in an outdoor space
+              <br />
+              🥪 You're indoors while consuming food, socially distanced
+              <br />
+              👂 You're communicating with someone hearing impaired
+              <br />
+              🎤 You're a speaker presenting at the podium or on stage
               <br />
               <br />
-              If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action. If you are not interested in attending in person due to the mask and vaccine requirements, you are welcome to book an <a href="{{site.ticket_link}}">online ticket</a>.
+              If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action. If you are not interested in attending in person due to the mask and test requirements, you are welcome to book an <a href="{{site.ticket_link}}">online ticket</a>.
             </p>
         </div>
     </div>


### PR DESCRIPTION
I removed the references to ShareMy.health in case we don't use them for the test verification process.