### PR TITLE
🔧 Fix dates for 2023 on about page

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -29,7 +29,7 @@ title: About DjangoCon US 2023
     </div>
   </section>
 
-  {% comment %}
+
   <section class="section-pad theme-medium-gray">
     <div class="row column xlarge-9">
       <h2 class="text-center">Pre-Conference</h2>
@@ -38,8 +38,8 @@ title: About DjangoCon US 2023
         <div class="row collapse">
           <div class="small-5 column">
             <div class="dates">
-              <div class="month">JUNE</div>
-              <div class="days">10</div>
+              <div class="month">May</div>
+              <div class="days">15</div>
             </div>
           </div>
           <div class="small-7 column">
@@ -51,8 +51,8 @@ title: About DjangoCon US 2023
         <div class="row collapse">
           <div class="small-5 column">
             <div class="dates">
-              <div class="month">JUNE</div>
-              <div class="days">10</div>
+              <div class="month">May</div>
+              <div class="days">15</div>
             </div>
           </div>
           <div class="small-7 column">
@@ -64,8 +64,8 @@ title: About DjangoCon US 2023
         <div class="row collapse">
           <div class="small-5 column">
             <div class="dates">
-              <div class="month">JULY</div>
-              <div class="days">8</div>
+              <div class="month">June</div>
+              <div class="days">28</div>
             </div>
           </div>
           <div class="small-7 column">
@@ -83,7 +83,6 @@ title: About DjangoCon US 2023
       </div>
     </div>
   </section>
-  {% endcomment %}
 
   <section class="section-pad theme-brand-color4">
     <div class="row column xlarge-9">
@@ -94,7 +93,7 @@ title: About DjangoCon US 2023
           <div class="small-5 column">
             <div class="dates">
               <div class="month">Oct</div>
-              <div class="days">17-19</div>
+              <div class="days">16-18</div>
             </div>
           </div>
           <div class="small-7 column">
@@ -108,7 +107,7 @@ title: About DjangoCon US 2023
           <div class="small-5 column">
             <div class="dates">
               <div class="month">Oct</div>
-              <div class="days">20-21</div>
+              <div class="days">19-20</div>
             </div>
           </div>
           <div class="small-7 column">
@@ -118,6 +117,7 @@ title: About DjangoCon US 2023
         </div>
       </div>
     </div>
+    {% comment %}
     <div class="row column v-pad-top">
       <div class="medium-4 medium-centered column">
         <div class="button-group expanded">
@@ -125,6 +125,7 @@ title: About DjangoCon US 2023
         </div>
       </div>
     </div>
+    {% endcomment %}
   </section>
 
   <section class="section-pad theme-brand-color3">


### PR DESCRIPTION
Also bring back the pre-conference schedule block

Addresses #76

Screenshot with the old theme:
![image](https://user-images.githubusercontent.com/7773256/236508545-451ef021-ad89-45b0-af38-a869800c985f.png)
