### PR TITLE
🔧 More home layout fixes

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,10 +18,8 @@ layout: base
         </span>
       </div>
 
-      {% comment %}
       <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
       <a class="button" href="{{ site.cfp_application }}">Submit Talk</a>
-      {% endcomment %}
 
       <a class="button" href="https://emails.djangocon.us/sendy/subscription?f=Gs892S6cdJ676370nkSBxLOWzUsgYKPBcwkEMMvt0rr70f3IeA7634kuMTKJCLrdcgOQHQHdzwqLwvmcETbcm6KWtu9g">Join Mailing List</a>
       {% comment %}
@@ -104,6 +102,7 @@ layout: base
         </div>
       </div>
     </div>
+    {% comment %}
     <div class="medium-4 column">
       <div class="card">
         <img
@@ -117,6 +116,7 @@ layout: base
         </div>
       </div>
     </div>
+    {% endcomment %}
     <div class="medium-4 column">
       <div class="card">
         <img

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -98,7 +98,7 @@ layout: base
           />
         <div class="card-section">
           <h3 class="card-title">COVID-19</h3>
-          <p>Read our <a href="/covid">COVID-19 Policy</a>, including mask and vaccine requirements.</p>
+          <p>Read our <a href="/covid">COVID-19 Policy</a>, including mask and testing requirements.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
1. Drops the conference schedule bit from the 3 cards under "A Conference with Heart". For now I'm just going with 2 columns mainly because I can't find what we used as a third card before the schedule was launched.
2. Adds buttons to buy tickets and submit a talk to the hero

Addresses #76 