### PR TITLE
Disable links to talks, sprints, tutorials.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,7 +33,8 @@ layout: base
 
 <div class="row column xlarge-9 theme-brand-color5 section-pad">
   <div class="date-card medium-4 column">
-    <a href="/tutorials/">
+    <!-- TODO: re-add link to /tutorials/ -->
+    <a href="#">
       <div class="dates">
         <div class="month">October</div>
         <div class="days card-bg-1">8</div>
@@ -41,11 +42,13 @@ layout: base
       <div class="details">
         <h2 class="date-card-title">Tutorials</h2>
         <p>One day, numerous tutorials</p>
+        <p><i>Coming soon!</i></p>
       </div>
     </a>
   </div>
   <div class="date-card medium-4 column">
-    <a href="/talks/">
+    <!-- TODO: re-add link to /talks/ -->
+    <a href="#">
       <div class="dates">
         <div class="month">October</div>
         <div class="days card-bg-2">16-18</div>
@@ -53,11 +56,13 @@ layout: base
       <div class="details">
         <h2 class="date-card-title">Talks</h2>
         <p>Dozens of talks chosen by the community</p>
+        <p><i>Coming soon!</i></p>
       </div>
     </a>
   </div>
   <div class="date-card medium-4 column">
-    <a href="/sprints/">
+    <!-- TODO: re-add link to /sprints/ -->
+    <a href="#">
       <div class="dates">
         <div class="month">October</div>
         <div class="days card-bg-3">19-20</div>
@@ -65,6 +70,7 @@ layout: base
       <div class="details">
         <h2 class="date-card-title">Sprints</h2>
         <p>Team up to work on Django!</p>
+        <p><i>Coming soon!</i></p>
       </div>
     </a>
   </div>


### PR DESCRIPTION
![coming_soon_tags](https://github.com/djangocon/2023.djangocon.us/assets/1281215/d3962846-3eaa-42a4-aa9c-1d8e61e9df81)

Addresses the issue where people have a navigable link to pages that have 2022 content.