### PR TITLE
✏️ Improve the speaking resources page for post-CFP stuff

### DIFF
--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -7,9 +7,11 @@ title: Speaker Resources
 ---
 
 ## Information for Speakers
+
 {% comment %}* The Speaker Green Room will be in <strong>Santa Fe 4</strong> on Sunday-Wednesday.{% endcomment %}
 * Please be in your presentation room at least 15 minutes before your talk to meet your session chair.
 * A Quiet Room will be available for attendees and speakers on all conference days.
+* We reserve the right to ask for a draft of your slides/notes not more than 3 weeks in advance of the presentation for review. This draft will not be shared with anyone outside the program and code of conduct teams.
 
 ## Need some help with your presentation?
 
@@ -26,21 +28,42 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * [Dr. Russell Keith-Magee](mailto:russell@keith-magee.com), Founder of the BeeWare project, developing GUI tools and libraries to support the development of Python software on desktop and mobile platforms. He is also a 13 year veteran of the Django Core Team, and for 5 years, was President of the Django Software Foundation. In his day job, he wrangles data pipelines for Survata.
 {% endcomment %}
 
+## Talk Guidelines
+
+### Accessibility
+
+* You can submit a draft copy of your slides with notes indicating what you plan to say a minimum of three weeks before your talk to give the captioners time to train on your data and therefore improve caption accuracy. This is extremely helpful to our attendees who read the live captions if you're using jargon beyond "Django" and "the ORM".
+* These slides will not be shared outside of the organizing team and the captioners. Send the slides to hello AT djangocon DOT us when you are ready. It's perfectly fine if your slides and notes change between the draft and final version.
+* When describing media in your talk (images, screenshots, graphs, videos, etc.), please give a verbal description of what you're showing so that blind or vision-impaired attendees can understand what you're describing.
+  * Example: instead of "here's a graph showing performance improvements with our new async code," say "here's a line graph showing our average response time that decreased from 450 milliseconds to 150 milliseconds after adding our new async code."
+
+### General
+
+* Use gender-neutral language wherever possible. Don't default to using "he" or "him" everywhere.
+* Be respectful of other speakers, your audience, and the community at large, especially when offering critiques. It's possible to say "this needs improvement" without saying "this is bad."
+* Consider including your social media handle(s) on your opening and closing slides! If you have space, you can even include them on the footer of every slide.
+* Consider publishing your slides after your talk (on the platform of your choice) and sharing the link with the #djangocon hashtag on social media.
+* Include a copy of what you plan to say in each slide's notes (if possible). This will help you while you're in presenter view and also make it easier for people who may be looking at your slides after the conference.
+* Before you connect your laptop to the projector, make sure you have every window except for your slides minimized or closed to avoid accidental information disclosure.
+* Make sure you turn on your computer's do not disturb mode before starting your presentation to avoid interruptions.
+* If your computer needs a dongle to connect to an HDMI cable, please bring it. We'll have most of the common ones, including a USB-C/Thunderbolt connector, but it always helps to have one that you know works.
 
 ## Slide Guidelines
 
-* Use Keynote, PowerPoint, LibreOffice, or Google Slides for your slides.
+### Format
+
 * Minimal slides are best—-avoid walls of text and long lists of bullets.
-* Aim for high contrast slides, avoiding colors that may be difficult to see for those with colorblindness. (You can [check your contrast online](http://webaim.org/resources/contrastchecker/); you just need the hex codes for your colors!)
 * Light background with dark text is easiest to read; be mindful that the projection screen is white.
-* Make text as large as possible, at least 68pt.
-* Choose fonts with adequate spacing between letters, and avoid thin or cursive fonts.
-* Leave the bottom ⅓ of your slides free of text to ensure nothing is obscured.
+ Choose fonts with adequate spacing between letters, and avoid thin or cursive fonts.
+* Leave the bottom 10⅓ of your slides free of text to ensure nothing is obscured by other attendees' heads.
 * If your talk requires live coding or using the terminal, make sure your editor or terminal settings are legible. Dark text on a light background (high contrast) with a large font is best.
-* Avoid or limit flashing videos or animated gifs, as these may have negative effects for people with seizure disorders, migraines, or ADD/ADHD.
 * Images, memes, and GIFs should be appropriate for a professional audience.
+
+### Accessibility
+
+* Aim for high contrast slides, avoiding colors that may be difficult to see for those with colorblindness. (You can [check your contrast online](http://webaim.org/resources/contrastchecker/); you just need the hex codes for your colors!)
+* Avoid or limit flashing videos or animated GIFs, as these may have negative effects for people with seizure disorders, migraines, or ADD/ADHD.
+* Make text as large as possible. People need to be able to read the text from a very long distance.
 * Your talk should lose nothing if the slides aren’t visible. Generally describe graphs, images, and other information for the audience.
-* Consider including your Twitter handle on your opening and closing slides!
-* Consider publishing your slides after your talk (on the platform of your choice) and tweeting the link with the #djangocon hashtag.
 
 Thanks to [AlterConf](https://www.alterconf.com/speak) for their amazing speaking recommendations!

--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -39,10 +39,10 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 
 ### General
 
-* Use gender-neutral language wherever possible. Don't default to using "he" or "him" everywhere.
+* Use gender-neutral language wherever possible. Don't default to [using "he", "him", or "guys"](https://heyguys.cc) everywhere.
 * Be respectful of other speakers, your audience, and the community at large, especially when offering critiques. It's possible to say "this needs improvement" without saying "this is bad."
 * Consider including your social media handle(s) on your opening and closing slides! If you have space, you can even include them on the footer of every slide.
-* Consider publishing your slides after your talk (on the platform of your choice) and sharing the link with the #djangocon hashtag on social media.
+* Consider publishing your slides after your talk (on the platform of your choice) and sharing the link with the #DjangoCon hashtag on social media.
 * Include a copy of what you plan to say in each slide's notes (if possible). This will help you while you're in presenter view and also make it easier for people who may be looking at your slides after the conference.
 * Before you connect your laptop to the projector, make sure you have every window except for your slides minimized or closed to avoid accidental information disclosure.
 * Make sure you turn on your computer's do not disturb mode before starting your presentation to avoid interruptions.
@@ -55,7 +55,7 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * Minimal slides are best—-avoid walls of text and long lists of bullets.
 * Light background with dark text is easiest to read; be mindful that the projection screen is white.
  Choose fonts with adequate spacing between letters, and avoid thin or cursive fonts.
-* Leave the bottom 10⅓ of your slides free of text to ensure nothing is obscured by other attendees' heads.
+* Leave the bottom 25% of your slides free of text to ensure nothing is obscured by other attendees' heads.
 * If your talk requires live coding or using the terminal, make sure your editor or terminal settings are legible. Dark text on a light background (high contrast) with a large font is best.
 * Images, memes, and GIFs should be appropriate for a professional audience.
 


### PR DESCRIPTION
1. Add notes about accessibility
2. Refactor slide guidelines to be separate from talk guidelines
3. Remove some notes about which software to use
4. Add the ability to submit talk slides in advance
5. Give some quick tips for hooking your laptop up to the projector

Fixes #6.

Screenshots:
![image](https://github.com/djangocon/2023.djangocon.us/assets/7773256/663b7c1f-079d-4d72-9daf-5fa05508c313)

![image](https://github.com/djangocon/2023.djangocon.us/assets/7773256/b4225fd5-90f0-47b3-8e1c-36e30122027f)

![image](https://github.com/djangocon/2023.djangocon.us/assets/7773256/4fee998f-3549-4437-8991-bc627ba63b18)

![image](https://github.com/djangocon/2023.djangocon.us/assets/7773256/a0e82d3f-9455-42ae-bf74-710497e6fda7)
