### PR TITLE
Send the proper webhook payload to Slack.

### DIFF
--- a/.github/workflows/deploy_hooks.yml
+++ b/.github/workflows/deploy_hooks.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   send_webhook:
-    if: ${{ github.event.deployment_status.state == 'success' }}
+    if: ${{ github.event.deployment_status == null || github.event.deployment_status.state == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Post blog published notification to Communications channel
@@ -56,10 +56,10 @@ jobs:
             // Check if the pull request has the 'blog' label
             if (label) {
               // Construct the payload for the webhook post
-              const payload = { title: prTitle, label: label.name };
+              const payload = { text: `Blog "${prTitle}" post has been published.` };
               const webhookUrl = "${{ env.WEBHOOK_URL }}";
               // Send the webhook post request
-              await fetch(webhookUrl, {
+              const fetchResponse = await fetch(webhookUrl, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify(payload),

--- a/.github/workflows/deploy_hooks.yml
+++ b/.github/workflows/deploy_hooks.yml
@@ -50,21 +50,24 @@ jobs:
             const response = await github.graphql(query, variables);
 
             // Extract relevant information from the response
-            const prTitle = response.repository.object.associatedPullRequests.nodes[0].title;
-            const label = response.repository.object.associatedPullRequests.nodes[0].labels.nodes.find(node => node.name === 'blog');
+            const prs = response.repository.object.associatedPullRequests.nodes
+            if (prs.length >= 1) {
+              const prTitle = prs[0].title;
+              const label = prs[0].labels.nodes.find(node => node.name === 'blog');
 
-            // Check if the pull request has the 'blog' label
-            if (label) {
-              // Construct the payload for the webhook post
-              const payload = { text: `Blog "${prTitle}" post has been published.` };
-              const webhookUrl = "${{ env.WEBHOOK_URL }}";
-              // Send the webhook post request
-              const fetchResponse = await fetch(webhookUrl, {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify(payload),
-              });
-            } else {
-              // Debugging measure. Should be removed after we know this all works.
-              console.log(prTitle, label, response)
+              // Check if the pull request has the 'blog' label
+              if (label) {
+                // Construct the payload for the webhook post
+                const payload = { text: `Blog "${prTitle}" post has been published.` };
+                const webhookUrl = "${{ env.WEBHOOK_URL }}";
+                // Send the webhook post request
+                const fetchResponse = await fetch(webhookUrl, {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify(payload),
+                });
+              } else {
+                // Debugging measure. Should be removed after we know this all works.
+                console.log(prTitle, label, response)
+              }
             }


### PR DESCRIPTION
Slack wants a payload with a text property.

This also supports actually running the workflow on demand by skipping the check if the event is a deployment_status update.