### PR TITLE
#125 Create PR template to apply blog label

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- Please make sure to apply the "blog" label to the pull request if it is related to a blog post so that it can be published to Slack. -->
 
 ## Description
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,3 @@
-<!-- 
-This PR template serves as a guide and reminder for contributors to ensure that the "blog" label is applied appropriately.
-Please make sure to apply the "blog" label to the pull request if it is related to a blog post so that it can be published to Slack. 
--->
 
 ## Description
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- 
+This PR template serves as a guide and reminder for contributors to ensure that the "blog" label is applied appropriately.
+Please make sure to apply the "blog" label to the pull request if it is related to a blog post so that it can be published to Slack. 
+-->
+
+## Description
+
+<!-- Add a description of the changes introduced by this PR -->
+
+## Related Issue
+
+<!-- If this PR is related to an issue, provide the issue number or a brief description -->
+
+## Checklist
+
+- [ ] I have applied the "blog" label to this pull request.
+- [ ] I have tested the changes locally.
+- [ ] I have reviewed the code changes.
+- [ ] I have updated the documentation, if necessary.
+- [ ] I have added appropriate tests, if applicable.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,11 +10,3 @@ Please make sure to apply the "blog" label to the pull request if it is related 
 ## Related Issue
 
 <!-- If this PR is related to an issue, provide the issue number or a brief description -->
-
-## Checklist
-
-- [ ] I have applied the "blog" label to this pull request.
-- [ ] I have tested the changes locally.
-- [ ] I have reviewed the code changes.
-- [ ] I have updated the documentation, if necessary.
-- [ ] I have added appropriate tests, if applicable.


### PR DESCRIPTION
This PR template serves as a guide and reminder for contributors to ensure that the "blog" label is applied when creating blogs so that it's published to Slack.

Hi @tim-schilling , thoughts on this?