### PR TITLE
✏️ Mark on the schedule page that tutorials are online

### DIFF
--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -32,11 +32,12 @@ title: Full Conference Schedule
 <!-- tutorials -->
 <section class="section-pad schedule" id="Day-Tutorials">
   <div class="row column">
-    <h2 class="day">Tutorials: Sunday, October 8</h2>
+    <h2 class="day">Tutorials: Sunday, October 8 (Online)</h2>
     <p class="lead">
       Tutorials are a separate registration and are $199 per session. Buy
       <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell
-      out!
+      out! All tutorials are online this year due to venue availability in
+      Durham.
     </p>
     <ul class="schedule">
       {% for post in site.schedule %} {% capture day %}{{ post.date | date: "%A"


### PR DESCRIPTION


## Description

Suggested by @emullaney: mark the tutorials as being online in the header on the schedule page