### PR TITLE
Support rendering pages without the nav and footer for iframes.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -51,6 +51,7 @@
     <!-- Loading JavaScripts
     ================================================== -->
     <script src="/static/main.js"></script>
+    <script src="/static/iframe_compat.js"></script>
     {% include analytics.html %}
   </body>
 </html>

--- a/_pages/iframe.html
+++ b/_pages/iframe.html
@@ -1,0 +1,33 @@
+---
+permalink: /iframe/
+layout: null
+sitemap: false
+published: false
+---
+<!doctype html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+      iframe {
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <p>This is a testing harness. Browse to
+      <code>
+        <a href="/iframe/?page=/conduct/">/iframe/?page=/conduct/</a>
+      </code>
+      to test the conduct page in an iframe.
+    </p>
+   <iframe id="iframe-test" src=""></iframe>
+  </body>
+  <script>
+    const iframe = document.getElementById('iframe-test')
+    iframe.src = 'http://localhost:4000'+(new URLSearchParams(window.location.search)).get('page')
+  </script>
+</html>

--- a/static/iframe_compat.js
+++ b/static/iframe_compat.js
@@ -1,0 +1,9 @@
+$(function() {
+  console.log('rendered', window.parent, window, window.parent !== window)
+  if (window.parent !== window) {
+    // We're in an iframe. Let's remove the navbar and the footer
+    $('nav,footer').remove()
+    // With no navbar, the top padding for the content can be removed
+    $('header.subpage-header').addClass('no-top')
+  }
+});

--- a/static/main.css
+++ b/static/main.css
@@ -7798,6 +7798,9 @@ blockquote p:last-of-type {
 .subpage-header.no-bottom {
   padding-bottom: 0;
 }
+.subpage-header.no-top {
+  padding-top: 0;
+}
 
 .subpage-header h1 {
   position: relative;


### PR DESCRIPTION
LoudSwarm wants to have links to various types of content that exists on our site already. Rather than duplicating and dealing with stale data, this allows our site to be more easily used in an iframe.

This relies on JavaScript to detect that we're in an iframe, then remove the bulky nav and footer elements. This means that if a user has JavaScript disabled (they're going to have a tough time on LoudSwarm) they would still see the header and footer. Additionally, if they are using a slower machine, the header and footer would remain visible for a noticeable amount of time. But again, they're probably going to have a bad time on the LoudSwarm platform.
