### PR TITLE
🏨 Update the hotel page to indicate that the room block is closed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -88,7 +88,6 @@ twitter:
 # This is the default logo that people see with opengraph
 logo: /static/img/social/share.jpg
 
-
 # Frontmatter fallback settings
 # This is the default logo that people see on blog posts
 defaults:
@@ -112,7 +111,7 @@ visa_email: "visas@djangocon.us"
 
 # Our DjangoCon US links
 cfp_application: "https://pretalx.com/djangocon-us-2023/cfp"
-hotel_reservation_link: "https://www.marriott.com/events/start.mi?id=1674740649947&key=GRP"
+hotel_reservation_link: "https://www.marriott.com/en-us/hotels/rducv-durham-marriott-city-center/overview/"
 # slack_link: "https://djangoconus2022.herokuapp.com"
 opportunity_grant_application: "https://forms.gle/LamfHzoXULdv63h18"
 slack_link: ""

--- a/_pages/venue.html
+++ b/_pages/venue.html
@@ -66,18 +66,20 @@ title: Venue
     <div class="medium-6 column">
       <h2>Staying at the Durham Marriott City Center</h2>
       <p class="lead min">
-        Our group rate of <strong>$189/night</strong> expires on
-        September&nbsp;15, so don't wait to book your room!
+        Our group rate has expired, but there are still rooms at the hotel.
+        Please don't wait to book your room!
       </p>
       <ul class="list-split">
         <li>Free Wi-Fi</li>
         <li>Room for hallway hacking</li>
         <li>In the middle of downtown</li>
       </ul>
+      {% comment %}
       <p>
         ATTENTION!: If you try to book and it says the capacity is full, please
         call the hotel to try to book your room.
       </p>
+      {% endcomment %}
       <p>
         <a href="{{ site.hotel_reservation_link }}" class="button"
           >Book a Room</a
@@ -91,10 +93,12 @@ title: Venue
   <div class="row column">
     <div class="medium-6 column">
       <h2>Other Hotel Options</h2>
+      {% comment %}
       <p class="lead min">
         Our room block at the Marriott is almost completely sold out, so check
         out these other nearby options!
       </p>
+      {% endcomment %}
 
       <ul class="list-split">
         <li>


### PR DESCRIPTION


## Description

Marks the room block as closed on the venue page and changes the hotel link to point to the hotel's main page

<img width="1239" alt="Screenshot 2023-09-14 at 11 25 47 AM" src="https://github.com/djangocon/2023.djangocon.us/assets/7773256/00699ec5-e387-4e3c-96b2-ec2680a0badf">
