### PR TITLE
Fix invalid HTML markup

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="footer" role="contentinfo">
+<footer class="footer">
 
   {% comment %}
   <a

--- a/_layouts/new_layout.html
+++ b/_layouts/new_layout.html
@@ -318,7 +318,7 @@
 
   </div>
 
-  <footer class="siteFooter" role="contentinfo">
+  <footer class="siteFooter">
     <ul class="socialIcons">
       <li>
         <a class="twitter" href="https://twitter.com/djangocon" target="_blank">

--- a/_layouts/post-list.html
+++ b/_layouts/post-list.html
@@ -6,7 +6,7 @@ permalink: /news/
 {% for post in site.posts %}
   {% unless post.hidden or post.category == 'talk' or post.category == 'tutorial' %}
   <article class="post-item">
-    <time class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</time>
+    <time class="post-meta" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</time>
     <h2 class="post-title">
       <a
         class="post-link"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: base
 ---
 
 <header class="subpage-header{% if page.post_photo_url %} has-post-photo{% endif %}">
-  <time class="post-meta">{{ page.date | date: "%b %-d, %Y" }}</time>
+  <time class="post-meta" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %-d, %Y" }}</time>
   <h1 class="post-title">{{ page.title }}</h1>
 </header>
 

--- a/_pages/homepage-coming-soon.html
+++ b/_pages/homepage-coming-soon.html
@@ -429,7 +429,7 @@ title: DjangoCon US 2023 will be at the Durham Convention Center in Durham, Nort
     </main>
   </div>
 
-  <footer class="siteFooter" role="contentinfo">
+  <footer class="siteFooter">
     <ul class="socialIcons">
       <li>
         <a class="twitter" href="https://twitter.com/djangocon" target="_blank">

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -86,7 +86,6 @@ title: Tickets
         <td><div>Companies with more than 5 employees</div><div>(including government agencies and nonprofits, if able)</div></td>
        </tr>
       <tr>
-      <tr>
        <td>Patron</td>
        <td>&mdash;</td>
        <td>$999</td>

--- a/_pages/venue.html
+++ b/_pages/venue.html
@@ -87,7 +87,7 @@ title: Venue
   </div>
 </section>
 
-<section class="section-pad theme-medium-gray" id="hotel">
+<section class="section-pad theme-medium-gray" id="other-hotels">
   <div class="row column">
     <div class="medium-6 column">
       <h2>Other Hotel Options</h2>


### PR DESCRIPTION
## Description

Related: #196. Fixes a number of occurrences of HTML markup causing validation errors or warnings. Each commit is for a fully separate issue.

- [Fix invalid table markup](https://github.com/djangocon/2023.djangocon.us/commit/aa9f5503e7625cd7018cd6f1d367bd73d750ea66) – just an extra `<tr>`.
- [Fix duplicate id on venue page](https://github.com/djangocon/2023.djangocon.us/commit/9ecc192dc761e80a75ffe33507596ab382837c6c) – two `#hotel` sections.
- [Add valid datetime attributes to time elements](https://github.com/djangocon/2023.djangocon.us/commit/64d751d5b8025c206ecb6423dd3b770e6c9c9c08) – the `<time>` element will only serve its purpose if its contents are either formatted in one of its supported formats, or if the `datetime` attribute does so.
- [Remove unnecessary footer role](https://github.com/djangocon/2023.djangocon.us/commit/aa63fe64ba049b10f6905e188f2fbc23196acf69) `role="contentinfo"` is what the `<footer>` tag does by default.

---

All of those issues were identified and fixes tested with [validator.nu](https://validator.nu/).