### PR TITLE
Fix incorrect time zone in session time link

### DIFF
--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -11,7 +11,7 @@ layout: base
       time-zone-name="short">
       {{ page.date | date: "%b %d %l:%M %p %Z" }}
     </local-time>
-    <a href="https://time.is/compare/{{ page.date | date: "%I%M%p_%d_%B_%Y" }}_in_Los_Angeles" aria-label="View talk time on time.is">:calendar:</a>
+    <a href="https://time.is/compare/{{ page.date | date: "%I%M%p_%d_%B_%Y" }}_in_Durham" aria-label="View talk time on time.is">:calendar:</a>
     {% if page.end_date %} to {{ page.end_date | date: "%l:%M %P" }}{% endif %}
     {% comment %}, in {{ page.room }}{% endcomment %}
     {% if page.difficulty %}


### PR DESCRIPTION
<!-- Please make sure to apply the "blog" label to the pull request if it is related to a blog post so that it can be published to Slack. -->

## Description

Spotted while working on accessibility fixes – sessions weren’t using the correct time zone in those time zone links.