### PR TITLE
Add the Six Feet Up sponsored talk

### DIFF
--- a/_presenters/calvin-hendryx-parker.md
+++ b/_presenters/calvin-hendryx-parker.md
@@ -11,12 +11,12 @@ twitter: calvinhp
 website: null
 ---
 
-Calvin Hendryx-Parker is the co-founder and CTO of Six Feet Up, a Python and cloud expert consulting company that makes the world a better place by using technology to accelerate the initiatives of companies that do good.
+Calvin Hendryx-Parker is the co-founder and CTO of Six Feet Up, a Python and AI consulting company that makes the world a better place by using technology to accelerate the initiatives of companies that do good. Six Feet Up is a top 10 United States Custom Software Development Company according to Clutch.co.
 
 Calvin’s Massive Transformative Purpose (MTP) is to inspire and enable tech leaders to open minds and bring the world together for a sustainable future. At Six Feet Up, Calvin establishes the company's technical vision and leads all aspects of the company's technology development. He provides the strategic vision for enhancing the offerings of the company and infrastructure, and he works with the team to set company priorities and implement processes that will help improve product and service development.
 
 Calvin is passionate about the open source community and specializes in app development, AI, big data and cloud technology. He is regularly sought after to share his expertise — both at international conferences and in the media.
 
-In 2019, Calvin was named an AWS Hero — one of only 48 Heroes in North America. He is the founder and host of the Python Web Conference; the co-founder of IndyPy, the largest Python meetup in Indiana with 2,100+ members; and the founder of IndyAWS, the fastest growing cloud meetup in the state with 800+ members. Additionally, Calvin is the driving force behind LoudSwarm by Six Feet Up, a high impact virtual event platform that debuted in June 2020.
+In 2019, Calvin was named an AWS Hero — one of only 48 Heroes in North America. He is the co-founder of IndyPy, the largest Python meetup in Indiana with 2,100+ members; and the founder of IndyAWS, the fastest growing cloud meetup in the state with 800+ members. Additionally, Calvin is the driving force behind LoudSwarm by Six Feet Up, a high impact virtual event platform that debuted in June 2020.
 
-Outside of work, Calvin spends time tinkering with new devices like the AWS DeepRacer, CircuitPython and Raspberry Pi. He is an avid distance runner and ran the 2014 NYC Marathon to support the Innocence Project. Before the pandemic, Calvin and his family enjoyed annual extended trips to France where his wife Gabrielle, the CEO of Six Feet Up, is from. Calvin lives in Fishers, IN and holds a Bachelor of Science from Purdue University.
+Outside of work, Calvin spends time tinkering with new devices like the AWS DeepRacer, CircuitPython and Raspberry Pi. He is an avid distance runner and ran the 2014 NYC Marathon to support the Innocence Project. Calvin and his family enjoy annual extended trips to France where his wife Gabrielle, the CEO of Six Feet Up, is from. Calvin lives in Fishers, IN and holds a Bachelor of Science from Purdue University.

--- a/_schedule/talks/2023-10-16-10-30-t0-sponsored-talk-six-feet-up.md
+++ b/_schedule/talks/2023-10-16-10-30-t0-sponsored-talk-six-feet-up.md
@@ -1,0 +1,22 @@
+---
+abstract: "Ever sensed an unseen throttle on your team's potential? Get ready to unmask those bottlenecks and elevate your Django prowess. Explore the BEST framework with Six Feet Up CTO Calvin Hendryx-Parker. BEST is a catalyst designed by devs, for devs, to turbocharge team efficiency. Ready to up your game? Join Calvin and dive into insights to lay the groundwork for unmatched synergy."
+accepted: true
+category: talks
+date: 2023-10-16 10:30:00-04:00
+end_date: 2023-10-16 10:40:00-04:00
+group: talks
+layout: session-details
+permalink: /talks/sponsored-talk-six-feet-up/
+presenter_slugs:
+- calvin-hendryx-parker
+published: true
+room: Junior Ballroom
+sitemap: true
+schedule_layout: full
+slug: sponsored-talk-six-feet-up
+summary: ''
+tags: null
+title: "Sponsored Talk: Supercharge Your Django Dev Team: Introducing the BEST Framework"
+track: t0
+---
+Ever sensed an unseen throttle on your team's potential? Get ready to unmask those bottlenecks and elevate your Django prowess. Explore the BEST framework with Six Feet Up CTO Calvin Hendryx-Parker. BEST is a catalyst designed by devs, for devs, to turbocharge team efficiency. Ready to up your game? Join Calvin and dive into insights to lay the groundwork for unmatched synergy.


### PR DESCRIPTION

## Description
1. Updates Calvin's bio with new copy from Laura
2. Adds the Six Feet Up sponsored talk to Monday after the keynote

Screenshot:
![calvin-talk](https://github.com/djangocon/2023.djangocon.us/assets/7773256/0bb42d12-fbf7-42ee-a596-ac6bd097756c)
