### PR TITLE
🔧 Skip unused talks in shot generation

### DIFF
--- a/bin/process.py
+++ b/bin/process.py
@@ -768,10 +768,18 @@ def generate_shots(
     quality: int = 80,
     width: int = 1200,
 ):
+    schedules = Path('_schedule').glob('**/*.md')
+    used_talks: set[str] = set()
+    for schedule in schedules:
+        post = frontmatter.loads(schedule.read_text())
+        if 'presenter_slugs' in post:
+            used_talks |= set(post['presenter_slugs'])
     presenters = Path("_presenters").glob("*.md")
     presenters = sorted(presenters, key=os.path.getmtime)
     for presenter in presenters:
         post = frontmatter.loads(presenter.read_text())
+        if post['slug'] not in used_talks:
+            continue
         print(f"- output: ./static/img/social/presenters/{post['slug']}.png")
         print(f"  height: {height}")
         print(f"  quality: {quality}")

--- a/shots.yml
+++ b/shots.yml
@@ -28,12 +28,6 @@
   width: 1200
   url: https://2023.djangocon.us/presenters/benjamin-zags-zagorsky/
 
-- output: ./static/img/social/presenters/calvin-hendryx-parker.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/calvin-hendryx-parker/
-
 - output: ./static/img/social/presenters/chaim-kirby.png
   height: 630
   quality: 80
@@ -94,23 +88,11 @@
   width: 1200
   url: https://2023.djangocon.us/presenters/drishti-jain/
 
-- output: ./static/img/social/presenters/eliana-rosselli.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/eliana-rosselli/
-
 - output: ./static/img/social/presenters/elizabeth-christensen.png
   height: 630
   quality: 80
   width: 1200
   url: https://2023.djangocon.us/presenters/elizabeth-christensen/
-
-- output: ./static/img/social/presenters/ernesto-rico-schmidt.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/ernesto-rico-schmidt/
 
 - output: ./static/img/social/presenters/felipe.png
   height: 630
@@ -142,12 +124,6 @@
   width: 1200
   url: https://2023.djangocon.us/presenters/josh-thomas/
 
-- output: ./static/img/social/presenters/julia-solorzano.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/julia-solorzano/
-
 - output: ./static/img/social/presenters/kojo-idrissa.png
   height: 630
   quality: 80
@@ -159,12 +135,6 @@
   quality: 80
   width: 1200
   url: https://2023.djangocon.us/presenters/kuldeep-pisda/
-
-- output: ./static/img/social/presenters/marc-gibbons.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/marc-gibbons/
 
 - output: ./static/img/social/presenters/mario-munoz.png
   height: 630
@@ -183,12 +153,6 @@
   quality: 80
   width: 1200
   url: https://2023.djangocon.us/presenters/michael-trythall/
-
-- output: ./static/img/social/presenters/mike-hoolehan.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/mike-hoolehan/
 
 - output: ./static/img/social/presenters/mohamed-elkalioby.png
   height: 630
@@ -232,12 +196,6 @@
   width: 1200
   url: https://2023.djangocon.us/presenters/paul-gilzow/
 
-- output: ./static/img/social/presenters/pavel-sviridov.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/pavel-sviridov/
-
 - output: ./static/img/social/presenters/peter-grandstaff.png
   height: 630
   quality: 80
@@ -268,23 +226,11 @@
   width: 1200
   url: https://2023.djangocon.us/presenters/ronald-maravanyika/
 
-- output: ./static/img/social/presenters/ryan-cheley.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/ryan-cheley/
-
 - output: ./static/img/social/presenters/sage-abdullah.png
   height: 630
   quality: 80
   width: 1200
   url: https://2023.djangocon.us/presenters/sage-abdullah/
-
-- output: ./static/img/social/presenters/scott-cranfill.png
-  height: 630
-  quality: 80
-  width: 1200
-  url: https://2023.djangocon.us/presenters/scott-cranfill/
 
 - output: ./static/img/social/presenters/sheena-o-connell.png
   height: 630
@@ -333,4 +279,58 @@
   quality: 80
   width: 1200
   url: https://2023.djangocon.us/presenters/wes-kendall/
+
+- output: ./static/img/social/presenters/calvin-hendryx-parker.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/calvin-hendryx-parker/
+
+- output: ./static/img/social/presenters/eliana-rosselli.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/eliana-rosselli/
+
+- output: ./static/img/social/presenters/ernesto-rico-schmidt.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/ernesto-rico-schmidt/
+
+- output: ./static/img/social/presenters/julia-solorzano.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/julia-solorzano/
+
+- output: ./static/img/social/presenters/marc-gibbons.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/marc-gibbons/
+
+- output: ./static/img/social/presenters/mike-hoolehan.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/mike-hoolehan/
+
+- output: ./static/img/social/presenters/pavel-sviridov.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/pavel-sviridov/
+
+- output: ./static/img/social/presenters/ryan-cheley.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/ryan-cheley/
+
+- output: ./static/img/social/presenters/scott-cranfill.png
+  height: 630
+  quality: 80
+  width: 1200
+  url: https://2023.djangocon.us/presenters/scott-cranfill/
 


### PR DESCRIPTION
## Description

If a speaker isn't referenced in any talks, don't regenerate their opengraph images. This should help with creating images for speakers with no talk titles.