### PR TITLE
📆 Add the sponsored talk from Platform.sh to the schedule

### DIFF
--- a/_schedule/talks/2023-10-18-t0-sponsored-talk-platform-sh.md
+++ b/_schedule/talks/2023-10-18-t0-sponsored-talk-platform-sh.md
@@ -1,0 +1,25 @@
+---
+abstract: When applications fall short of performance expectations - they are consuming too much memory, response times increase, etc. - it can be tempting to increase the resources in the environment to respond. At the heart of the issue is application performance, and what's missing is a comprehensive strategy that connects production monitoring to tools that allow you to identify bottlenecks and enforce performance expectations (a performance budget) in development.\n\nIn this talk, I'll attempt to show how using Blackfire.io in combination with Platform.sh as a deployment target makes it possible to not only create a Continuous Observability strategy across every application in your organization, but also how the pair makes it possible to make the environmental impact of web development a measurable and optimizable objective.
+accepted: true
+category: talks
+date: 2023-10-18 10:30:00-04:00
+end_date: 2023-10-18 10:40:00-04:00
+group: talks
+layout: session-details
+permalink: /talks/sponsored-talk-platform-sh/
+presenter_slugs:
+    - paul-gilzow
+published: true
+room: Junior Ballroom
+schedule_layout: full
+sitemap: true
+slug: sponsored-talk-platform-sh
+summary: ""
+tags: null
+title: "Sponsored Talk: Optimizing Django deployments with a Continuous Observability Strategy."
+track: t0
+---
+
+When applications fall short of performance expectations - they are consuming too much memory, response times increase, etc. - it can be tempting to increase the resources in the environment to respond. At the heart of the issue is application performance, and what's missing is a comprehensive strategy that connects production monitoring to tools that allow you to identify bottlenecks and enforce performance expectations (a performance budget) in development.
+
+In this talk, I'll attempt to show how using Blackfire.io in combination with Platform.sh as a deployment target makes it possible to not only create a Continuous Observability strategy across every application in your organization, but also how the pair makes it possible to make the environmental impact of web development a measurable and optimizable objective.


### PR DESCRIPTION

## Description

Adds the platform.sh sponsored talk to our schedule
![Screenshot 2023-10-10 at 1 11 02 PM](https://github.com/djangocon/2023.djangocon.us/assets/7773256/3d9573c5-dc92-4167-ad30-19706f5b5f01)
![Screenshot 2023-10-10 at 1 10 49 PM](https://github.com/djangocon/2023.djangocon.us/assets/7773256/a1fa8b58-59ca-4227-880b-43cfbd511d0c)

