### PR TITLE
🔧 Fix the speaker image for the Platform.sh sponsored talk

### DIFF
--- a/_presenters/dawn-wages.md
+++ b/_presenters/dawn-wages.md
@@ -4,7 +4,7 @@ hidden: false
 layout: speaker-template
 mastodon: https://mastodon.online/@bajoranengineer
 name: Dawn Wages
-override_schedule_title: "Navigating Django's Future: Djangonaut Space"
+override_schedule_title: 'Navigating Django''s Future: Djangonaut Space'
 permalink: /presenters/dawn-wages/
 photo_url: /static/img/presenters/dawn-wages.jpeg
 slug: dawn-wages

--- a/_schedule/talks/2023-10-18-10-30-t0-sponsored-talk-platform-sh.md
+++ b/_schedule/talks/2023-10-18-10-30-t0-sponsored-talk-platform-sh.md
@@ -15,7 +15,7 @@ category: talks
 date: 2023-10-18 10:30:00-04:00
 end_date: 2023-10-18 10:40:00-04:00
 group: talks
-image: https://2023.djangocon.us//static/img/social/presenters/paul-gilzow.png
+image: https://2023.djangocon.us//static/img/social/presenters/guillaume-moigneu.png
 layout: session-details
 permalink: /talks/sponsored-talk-platform-sh/
 presenter_slugs:


### PR DESCRIPTION
## Description
Just fixes the speaker image URL for Guillaume's talk