### PR TITLE
🔧 Hide the "buy tickets" links since tickets are no longer on sale

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -52,6 +52,7 @@
   </ul>
 </li>
 <li><a href="/news/">News</a></li>
+{% comment %}
 <li>
   <span>
     <a href="{{ site.ticket_link }}" class="button hollow"> Buy Tickets </a>
@@ -61,3 +62,4 @@
     </a>
   </span>
 </li>
+{% endcomment %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -18,8 +18,8 @@ layout: base
         </span>
       </div>
 
-      <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
       {% comment %}
+      <a class="button" href="{{ site.ticket_link }}">Buy Tickets</a>
       <a class="button" href="{{ site.cfp_application }}">Submit Talk</a>
       {% endcomment %}
 

--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -59,10 +59,11 @@ layout: base
         {% endcase %}
       </h2>
       {{ content }}
-
+      {% comment %}
       <a href="{{ site.ticket_link }}" class="button">
         Buy Tickets Now
       </a>
+      {% endcomment %}
 
     </div>
   </div><!-- end .row -->

--- a/_pages/covid19.html
+++ b/_pages/covid19.html
@@ -75,7 +75,10 @@ title: COVID-19 In-Person Policy
               🎤 You're a speaker presenting at the podium or on stage
               <br />
               <br />
-              If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action. If you are not interested in attending in person due to the mask and test requirements, you are welcome to book an <a href="{{site.ticket_link}}">online ticket</a>.
+              If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action.
+              {% comment %}
+              If you are not interested in attending in person due to the mask and test requirements, you are welcome to book an <a href="{{site.ticket_link}}">online ticket</a>.
+              {% endcomment %}
             </p>
         </div>
     </div>

--- a/_pages/faqs.html
+++ b/_pages/faqs.html
@@ -28,7 +28,9 @@ title: Frequently Asked Questions
           {% endcomment %}
           <li>I cannot attend DjangoCon US after all. Can I get a refund, or transfer my ticket to someone else?</li>
           <li>Can I switch the tutorial I registered for, as long as there is still space available in the tutorial I would like to take instead?</li>
+          {% comment %}
           <li>Do <a href="{{ site.ticket_link }}">tutorials</a> cost extra?</li>
+          {% endcomment %}
           <li>Do I have to register for sprints?</li>
           <li>Can I come to sprints even if I forgot to register?</li>
           <li>Can I register for a tutorial without registering for the whole conference?</li>

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -34,10 +34,11 @@ title: Full Conference Schedule
   <div class="row column">
     <h2 class="day">Tutorials: Sunday, October 8 (Online)</h2>
     <p class="lead">
-      Tutorials are a separate registration and are $199 per session. Buy
+      Tutorials are a separate registration and are $199 per session. {% comment
+      %}Buy
       <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell
-      out! All tutorials are online this year due to venue availability in
-      Durham.
+      out! {% endcomment %} All tutorials are online this year due to venue
+      availability in Durham.
     </p>
     <ul class="schedule">
       {% for post in site.schedule %} {% capture day %}{{ post.date | date: "%A"

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -20,10 +20,12 @@ title: Tickets
       </p>
       <h2>Which ticket should I buy?</h2>
       <p>Most people should buy an <strong>Individual</strong> ticket. If your company is paying, they should use the <strong>Corporate</strong> rate (or the <strong>Concierge</strong> rate for more flexibility; see below). For those who can't afford the Individual ticket, a <strong>discounted</strong> ticket is available; see below. And for those who want to go above and beyond and support our mission, check out the <strong>Patron</strong> ticket.</p>
+      {% comment %}
       <a
         class="button"
         href="{{ site.ticket_link }}"
         target="_blank">Buy Tickets Now</a>
+      {% comment %}
     </div>
 
     <div class="show-for-medium column medium-5">

--- a/_pages/tickets.html
+++ b/_pages/tickets.html
@@ -13,10 +13,11 @@ title: Tickets
 <div class="section-pad theme-light-gray">
   <div class="row" id="welcome">
     <div class="column small-12 medium-6">
-      {% comment %}
       <h2>DjangoCon US 2023 tickets are no longer on sale</h2>
-      <p>But if you want to see what they cost, or need to consult the refund policy, keep reading!</p>
-      {% endcomment %}
+      <p>
+        But if you want to see what they cost, or need to consult the refund
+        policy, keep reading!
+      </p>
       <h2>Which ticket should I buy?</h2>
       <p>Most people should buy an <strong>Individual</strong> ticket. If your company is paying, they should use the <strong>Corporate</strong> rate (or the <strong>Concierge</strong> rate for more flexibility; see below). For those who can't afford the Individual ticket, a <strong>discounted</strong> ticket is available; see below. And for those who want to go above and beyond and support our mission, check out the <strong>Patron</strong> ticket.</p>
       <a

--- a/_pages/tutorials.html
+++ b/_pages/tutorials.html
@@ -13,9 +13,10 @@ title: Tutorials Schedule
   <div class="row column">
     <h2 class="day">Tutorials: Sunday, October 8 (Online)</h2>
     <p class="lead">
-      Tutorials are a separate registration and are $199 per session. Buy
+      Tutorials are a separate registration and are $199 per session. {% comment
+      %} Buy
       <a href="{{ site.ticket_link }}">tutorial tickets</a> before they sell
-      out!
+      out! {% endcomment %}
     </p>
     <ul class="schedule">
       {% for post in site.schedule %} {% capture day %}{{ post.date | date: "%A"


### PR DESCRIPTION
Pages affected:
- Home page
- Top nav
- Schedule page
- Ticket page
- Tutorials schedule page


Switches the HTML comments to template contents so the links aren't visible in the HTML.