### PR TITLE
Update date in COVID-19 policy

### DIFF
--- a/_pages/covid19.html
+++ b/_pages/covid19.html
@@ -1,6 +1,6 @@
 ---
 description: DjangoCon US is committed to providing a safe in-person conference through
-  the use of vaccine verification and a mask mandate.
+the use of vaccine verification and a mask mandate.
 heading: COVID-19 In-Person Policy
 layout: base
 permalink: /covid/
@@ -14,73 +14,73 @@ title: COVID-19 In-Person Policy
 <div class="content subpage-content">
   <section class="section-pad">
     <div class="row column">
-        <h2 class="demp">
+      <h2 class="demp">
         DjangoCon US is committed to providing a safe in-person conference through the use of testing and a mask mandate.
-        </h2>
+      </h2>
     </div>
   </section>
 
   <section class="section-pad theme-light-gray">
     <div class="row">
-        <div class="column medium-9 medium-centered">
-          <h3 id="check-in-procedure">Check-in Procedure</h3>
-          <p>
-            We're asking that all registrants go through the COVID-19 check-in process before registration.
-            The COVID-19 registration area will consist of two tables, one for taking tests and the other
-            for showing proof of a negative test and acquiring a mask. Further on will be the conference
-            registration desk with your badge.
-          </p>
-          <ol>
-            <li>Acquire and wear N95/KN95 equivalent mask (we have them at the table)</li>
-            <li>Take COVID-19 test (follow instructions on the box, perform the test at secondary table or at home/the hotel)</li>
-            <li>Show photo of negative test at COVID-19 desk with handwritten note containing the date</li>
-            <li>Proceed to registration desk</li>
-          </ol>
-          <p>
-            If you have taken a test 24 hours within the start of the conference, you do not have to take
-            another test. Here is an example of a negative test with the date:
-            <br>
-            <img alt="A negative COVID-19 test with a phone showing the current date." src="{{ '/static/img/covid/covid19_test_example.png' | relative_url }}" />
-          </p>
-        </div>
+      <div class="column medium-9 medium-centered">
+        <h3 id="check-in-procedure">Check-in Procedure</h3>
+        <p>
+          We're asking that all registrants go through the COVID-19 check-in process before registration.
+          The COVID-19 registration area will consist of two tables, one for taking tests and the other
+          for showing proof of a negative test and acquiring a mask. Further on will be the conference
+          registration desk with your badge.
+        </p>
+        <ol>
+          <li>Acquire and wear N95/KN95 equivalent mask (we have them at the table)</li>
+          <li>Take COVID-19 test (follow instructions on the box, perform the test at secondary table or at home/the hotel)</li>
+          <li>Show photo of negative test at COVID-19 desk with handwritten note containing the date</li>
+          <li>Proceed to registration desk</li>
+        </ol>
+        <p>
+          If you have taken a test 24 hours within the start of the conference, you do not have to take
+          another test. Here is an example of a negative test with the date:
+          <br>
+          <img alt="A negative COVID-19 test with a phone showing the current date." src="{{ '/static/img/covid/covid19_test_example.png' | relative_url }}" />
+        </p>
+      </div>
     </div>
     <hr>
     <div class="row">
-        <div class="column medium-9 medium-centered">
-            <h3 id="covid-19-policy">COVID-19 Policy</h3>
-            <p>
-              In order to keep conference attendees safe, DjangoCon US will have an indoor mask mandate and require proof of a negative COVID test. We strongly recommend that people get fully vaccinated and boosted before the conference as well. If you are not familiar, we suggest you check out the <a href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-during-covid19.html">CDC's Domestic Travel guidelines to stay safe</a>.
-              <br />
-              <br />
-              We are requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a rapid test, you must take it within 24 hours of your first ticketed day. We will have tests on site if you wish to test when you arrive. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending Monday's sessions, the test must be taken no earlier than Thursday, October 13).
-              <br />
-              <br />
-              We will be sending the testing instructions to in-person ticket-holders prior to the conference.
-              <br />
-              <br />
-              The conference will provide KN95 and/or N95 masks for people to wear. We will be asking that all attendees wear a certified KN95 / N95 respirator mask (with no outflow vent) while inside. As N95 is an American standard, masks certified by other governments to similar standards (e.g. PM2.5 and KF94) will also be allowed.
-              <br />
-              <br />
-              Similar to DjangoCon US 2022, we will have a three strike policy for masks not being worn inside the venue. If you are seen without a mask on, you will be issued a strike by the organizing committee. Upon receiving your third strike, you will not be allowed to enter the venue and will not be issued a refund. Please make our job easy and keep your mask on while inside at all times.
-              <br />
-              <br />
-              The following cases are the only exceptions to not wear a mask while at the venue:
-              <br />
-              🌞 You're in an outdoor space
-              <br />
-              🥪 You're indoors while consuming food, socially distanced
-              <br />
-              👂 You're communicating with someone hearing impaired
-              <br />
-              🎤 You're a speaker presenting at the podium or on stage
-              <br />
-              <br />
-              If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action.
+      <div class="column medium-9 medium-centered">
+        <h3 id="covid-19-policy">COVID-19 Policy</h3>
+        <p>
+          In order to keep conference attendees safe, DjangoCon US will have an indoor mask mandate and require proof of a negative COVID test. We strongly recommend that people get fully vaccinated and boosted before the conference as well. If you are not familiar, we suggest you check out the <a href="https://www.cdc.gov/coronavirus/2019-ncov/travelers/travel-during-covid19.html">CDC's Domestic Travel guidelines to stay safe</a>.
+          <br />
+          <br />
+          We are requiring a negative test before coming to the registration desk on your first day of attendance. If you are taking a rapid test, you must take it within 24 hours of your first ticketed day. We will have tests on site if you wish to test when you arrive. If you are taking a PCR test, it must be within 3 days of your first ticketed day (e.g. if you are attending Monday's sessions, the test must be taken no earlier than Friday, October 13).
+          <br />
+          <br />
+          We will be sending the testing instructions to in-person ticket-holders prior to the conference.
+          <br />
+          <br />
+          The conference will provide KN95 and/or N95 masks for people to wear. We will be asking that all attendees wear a certified KN95 / N95 respirator mask (with no outflow vent) while inside. As N95 is an American standard, masks certified by other governments to similar standards (e.g. PM2.5 and KF94) will also be allowed.
+          <br />
+          <br />
+          Similar to DjangoCon US 2022, we will have a three strike policy for masks not being worn inside the venue. If you are seen without a mask on, you will be issued a strike by the organizing committee. Upon receiving your third strike, you will not be allowed to enter the venue and will not be issued a refund. Please make our job easy and keep your mask on while inside at all times.
+          <br />
+          <br />
+          The following cases are the only exceptions to not wear a mask while at the venue:
+          <br />
+          🌞 You're in an outdoor space
+          <br />
+          🥪 You're indoors while consuming food, socially distanced
+          <br />
+          👂 You're communicating with someone hearing impaired
+          <br />
+          🎤 You're a speaker presenting at the podium or on stage
+          <br />
+          <br />
+          If you have questions about the COVID-19 policy, please <a href="mailto:{{site.contact_us_email}}">email us</a>. If you need a medical exemption or the like, sending us an email is also the right course of action.
               {% comment %}
               If you are not interested in attending in person due to the mask and test requirements, you are welcome to book an <a href="{{site.ticket_link}}">online ticket</a>.
               {% endcomment %}
-            </p>
-        </div>
+        </p>
+      </div>
     </div>
   </section>
 </div><!-- end .content -->


### PR DESCRIPTION
## Description

October 13 is (was) a Friday, not a Thursday. While this was in the past and
is now unlikely to cause any problems with when people took a test, it's good to
have the correct information. Especially if someone is going to use this page as
the basis for 2024, it will make it easier for them to update.
