### PR TITLE
:hammer: Updates youtube templates for 2023

### DIFF
--- a/_includes/youtube-copy-and-paste.html
+++ b/_includes/youtube-copy-and-paste.html
@@ -3,17 +3,18 @@
 This talk was presented at: {{ site.url }}{{ include.post.url }}
 
 LINKS:{% if include.presenter_slugs %}{% for presenter_slug in post.presenter_slugs %}{% assign presenter = site.presenters | where: "slug", presenter_slug | first %}
-  Follow {{ presenter.name }} 👇
-  {% if presenter.twitter != blank %}On Twitter: https://twitter.com/{{ presenter.twitter }}
-  {% endif %}{% if presenter.github != blank %}On GitHub: https://github.com/{{ presenter.github }}
-  {% endif %}{% if presenter.website != blank %}Website: {{ presenter.website }}{% endif %}
+Follow {{ presenter.name }} 👇
+{% if presenter.github != blank %}On GitHub: https://github.com/{{ presenter.github }}
+{% endif %}{% if presenter.twitter != blank %}On Twitter: https://twitter.com/{{ presenter.twitter }}
+{% endif %}{% if presenter.website != blank %}Website: {{ presenter.website }}
+{% endif %}
 {% endfor %}{% endif %}
 
 Follow DjangCon US 👇
+https://fosstodon.org/@djangocon
 https://twitter.com/djangocon
 
 Follow DEFNA 👇
-https://twitter.com/defnado
 https://www.defna.org/
 
-Video production by the speaker and DjangoCon US 2021 Volunteers.
+Video production by the presenter and DjangoCon US 2023 volunteers.

--- a/_pages/speaking-youtube-checklists.md
+++ b/_pages/speaking-youtube-checklists.md
@@ -14,52 +14,61 @@ title: Speaking Checklists for YouTube Videos
 {% capture day %}{{ post.date | date: "%A" }}{% endcapture %}
 {% if day == 'Monday' or day == 'Tuesday' or day == 'Wednesday' %}
 {% if post.group == 'talks' or post.group == 'tutorials' %}
-<div class="event-byline">
-<h2>Video Checklist</h2>
+<section class="event-byline py-8 flex flex-col gap-4">
+<h2 class="text-3xl font-bold">Video Checklist</h2>
 
 {% capture youtube-copy-title %}copy-{{ post.slug | slugify }}-youtube{% endcapture %}
 
-<h4>{{ post.date | date: "%b %d %l:%M %p %Z" }} - <div id="{{ youtube-copy-title }}">{{ post.title }}</div></h4>
+<h4 class="text-2xl font-bold">{{ post.date | date: "%b %d %l:%M %p %Z" }} - <span id="{{ youtube-copy-title }}">{{ post.title }}</span></h4>
 
 <button class="btn bg-blue-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1" data-clipboard-action="copy" data-clipboard-target="#{{ youtube-copy-title }}">
 Copy title to clipboard
 </button>
 
 <div>
-  <a href="{{ post.video_url }}">On YouTube</a>
-  {% if post.additional_video_url %}<a href="{{ post.additional_video_url }}">Also on YouTube</a>{% endif %}
+  {% if post.video_url %}
+    <a class="btn bg-blue-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1" href="{{ post.video_url }}">
+      On YouTube
+    </a>
+  {% endif %}
+  {% if post.additional_video_url %}
+    <a class="btn bg-blue-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1" href="{{ post.additional_video_url }}">
+      Also on YouTube
+    </a>
+  {% endif %}
 </div>
 
-<ul>
-  <li><input type="checkbox">YouTube Premiere time set: {{ post.date | date: "%b %d %l:%M %p %Z" }}</li>
-  <li><input type="checkbox">Did the link above open the correct video?</li>
-  <li><input type="checkbox">Set title from this page</li>
-  <li><input type="checkbox">Set description from this page</li>
-  <li><input type="checkbox">Is it on the DjangoCon US 2021 Playlist?</li>
-  <li><input type="checkbox">Set to "not made for kids"</li>
-  <li><input type="checkbox">Set as "contains paid promotion"</li>
-  <li><input type="checkbox">Language set appropriately</li>
-  <li><input type="checkbox">Caption certification "has never aired on television"</li>
-  <li><input type="checkbox">Verify license is correct (YouTube Standard)</li>
-  <li><input type="checkbox">Allow embedding enabled</li>
-  <li><input type="checkbox">Publish to feed and notify subscribers enabled</li>
-  <li><input type="checkbox">Category: Education</li>
-  <li><input type="checkbox">Comments disabled</li>
-  <li><input type="checkbox">"show how many viewers like and dislike this video" disabled</li>
-  <li><input type="checkbox">English captions uploaded</li>
-  <li><input type="checkbox">Spanish captions uploaded</li>
-</ul>
+<div class="border-2 border-black round-2xl p-2">
+    <ul>
+      <li><input type="checkbox"> YouTube Premiere time set: {{ post.date | date: "%b %d %l:%M %p %Z" }}</li>
+      <li><input type="checkbox"> Did the link above open the correct video?</li>
+      <li><input type="checkbox"> Set title from this page</li>
+      <li><input type="checkbox"> Set description from this page</li>
+      <li><input type="checkbox"> Is it on the DjangoCon US 2023 Playlist?</li>
+      <li><input type="checkbox"> Set to "not made for kids"</li>
+      <li><input type="checkbox"> Set as "contains paid promotion"</li>
+      <li><input type="checkbox"> Language set appropriately</li>
+      <li><input type="checkbox"> Caption certification "has never aired on television"</li>
+      <li><input type="checkbox"> Verify license is correct (YouTube Standard)</li>
+      <li><input type="checkbox"> Allow embedding enabled</li>
+      <li><input type="checkbox"> Publish to feed and notify subscribers enabled</li>
+      <li><input type="checkbox"> Category: Education</li>
+      <li><input type="checkbox"> Comments disabled</li>
+      <li><input type="checkbox"> "show how many viewers like and dislike this video" disabled</li>
+      <li><input type="checkbox"> English captions uploaded</li>
+    </ul>
+</div>
 
-{% capture youtube-copy-link %}copy-{{ post.slug | slugify }}-youtube{% endcapture %}
+{% capture youtube-copy-link %}copy-{{ post.slug | slugify }}-youtube-link{% endcapture %}
 
-<textarea rows="10" id="{{ youtube-copy-link }}">
+<textarea class="border-2 border-black bg-yellow-100 round-2xl p-2" rows="10" id="{{ youtube-copy-link }}">
 {% include youtube-copy-and-paste.html post=post presenter_slugs=post.presenter_slugs %}
 </textarea>
 
-<button class="btn border" data-clipboard-action="copy" data-clipboard-target="#{{ youtube-copy-link }}">
+<button class="btn bg-blue-200 border-solid border-2 border-grey-800 rounded-lg px-2 py-1" data-clipboard-action="copy" data-clipboard-target="#{{ youtube-copy-link }}">
 Copy to clipboard
 </button>
-</div>
+</section>
 <hr>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
This updated our YouTube Checklist / Clipboard pages for 2023. 

![image](https://github.com/djangocon/2023.djangocon.us/assets/50527/12b3e3bb-4c94-4492-95c3-98c9b03e45a7)


I tried to get the Mastodon links to work but Jekyll assumes any content that starts with `@` should be formatted as a GitHub profile link and I couldn't figure it out. 🤷 